### PR TITLE
Avoid warning when WARN_CREATE_GLOBAL is active

### DIFF
--- a/async.zsh
+++ b/async.zsh
@@ -567,6 +567,7 @@ async_start_worker() {
 	# reassigned to /dev/null by the reassignment done inside the async
 	# worker.
 	# See https://github.com/mafredri/zsh-async/issues/35.
+	integer errfd
 	exec {errfd}>&2
 	zpty -b $worker _async_worker -p $$ $args 2>&$errfd || {
 		exec {errfd}>& -


### PR DESCRIPTION
Version 1.8.2's `$errfd` has to be declared as a local variable, or else we get the warning

    async_start_worker:37: numeric parameter errfd created globally in function async_start_worker

when the `zsh` option `WARN_CREATE_GLOBAL` is on.